### PR TITLE
Add bootable methods directly to the  ActivityLoggable trait

### DIFF
--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -22,7 +22,7 @@ trait ActivityLoggable
             ]);
         });
 
-        static::updating(function (Model $model) {
+        static::updating(function () {
             $diff = $this->getModelChangesJson(true); // true: If we want to limit the storage of fields defined in modelRelation; false : If we want to storage all model change
             $this->createActivityLog([
                 'title' => __('activity-log.actions.update').' #'.$this->id,
@@ -30,7 +30,7 @@ trait ActivityLoggable
             ]);
         });
 
-        static::deleting(function (Model $model) {
+        static::deleting(function () {
             $this->createActivityLog([
                 'title' => __('activity-log.actions.delete').' #'.$this->id,
                 'description' => '',

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -16,26 +16,41 @@ trait ActivityLoggable
     public static function bootActivityLoggable()
     {
         static::created(function() {
-            $this->createActivityLog([
-                'type' => ActivityLog::TYPE_DATA,
-                'title' => __('activity-log.actions.create').' #'.$this->id,
-            ]);
+            $this->logCreate();
         });
 
         static::updating(function () {
-            $diff = $this->getModelChangesJson(true); // true: If we want to limit the storage of fields defined in modelRelation; false : If we want to storage all model change
-            $this->createActivityLog([
-                'title' => __('activity-log.actions.update').' #'.$this->id,
-                'description' => $this->getModelChanges($diff),
-            ]);
+            $this->logUpdate();
         });
 
         static::deleting(function () {
-            $this->createActivityLog([
-                'title' => __('activity-log.actions.delete').' #'.$this->id,
-                'description' => '',
-            ]);
+            $this->logDelete();
         });
+    }
+
+    public function logCreate(): void
+    {
+        $this->createActivityLog([
+            'type' => ActivityLog::TYPE_DATA,
+            'title' => __('activity-log.actions.create').' #'.$this->id,
+        ]);
+    }
+
+    public function logUpdate(): void
+    {
+        $diff = $this->getModelChangesJson(true); // true: If we want to limit the storage of fields defined in modelRelation; false : If we want to storage all model change
+        $this->createActivityLog([
+            'title' => __('activity-log.actions.update').' #'.$this->id,
+            'description' => $this->getModelChanges($diff),
+        ]);
+    }
+
+    public function logDelete(): void
+    {
+        $this->createActivityLog([
+            'title' => __('activity-log.actions.delete').' #'.$this->id,
+            'description' => '',
+        ]);
     }
 
 


### PR DESCRIPTION
This PR allows the standard Observer actions to autoamatically be performed on any model that uses the `ActivityLoggable` trait.

Each `event` calls a method respectively `logCreate(0` `logUpdate()` `logDelete()` This means that is we need this to differ for any model we just created the method on the model and it will over ride the method on the trait.

There is no need to put any of these three standard items into observers creating duplicate code.

I will update readme if this is accepted


reference: https://freek.dev/1764-how-to-call-an-overridden-trait-function