### PR TITLE
default activity log name

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,29 @@ example. Add the following to the model
 `price` is the key for the field.
 Right hand side should be a closure than can then be used for format the value that will be present.
 
+You can override the default name / label for an entity. Simply create a method named `` that returns a string. Below is
+the default.
+
+```php
+ public function activityLogEntityName(): string
+  {
+
+      if (isset($this->name)) {
+          return $this->name;
+      }
+
+      if (isset($this->title)) {
+          return $this->title;
+      }
+
+      if (isset($this->label)) {
+          return $this->label;
+      }
+
+      return $this->id;
+  }
+```
+
 *`createCommunicationLog(array $data, string $to, string $content, string $type = CommunicationLog::TYPE_EMAIL): CommunicationLog`
 **: Create a new communication log.
 

--- a/README.md
+++ b/README.md
@@ -420,20 +420,7 @@ the default.
 ```php
  public function activityLogEntityName(): string
   {
-
-      if (isset($this->name)) {
-          return $this->name;
-      }
-
-      if (isset($this->title)) {
-          return $this->title;
-      }
-
-      if (isset($this->label)) {
-          return $this->label;
-      }
-
-      return $this->id;
+      return \Illuminate\Support\Str::title(class_basename($this));
   }
 ```
 

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -60,20 +60,7 @@ trait ActivityLoggable
 
     public function activityLogEntityName(): string
     {
-
-        if (isset($this->name)) {
-            return $this->name;
-        }
-
-        if (isset($this->title)) {
-            return $this->title;
-        }
-
-        if (isset($this->label)) {
-            return $this->label;
-        }
-
-        return $this->id;
+        return Str::title(class_basename($this));
     }
 
     public function logUpdate(): void

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -60,7 +60,7 @@ trait ActivityLoggable
 
     public function activityLogEntityName(): string
     {
-        return Str::title(class_basename($this));
+        return Str::title(class_basename($this)).' (id:'.$this->id.')';
     }
 
     public function logUpdate(): void

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -32,7 +32,7 @@ trait ActivityLoggable
     {
         $this->createActivityLog([
             'type' => ActivityLog::TYPE_DATA,
-            'title' => __('activity-log.actions.create').' #'.$this->id,
+            'title' => __('activity-log.actions.create').' #'.$this->activityLogEntityName(),
         ]);
     }
 
@@ -58,11 +58,29 @@ trait ActivityLoggable
         return $this;
     }
 
+    public function activityLogEntityName(): string
+    {
+
+        if (isset($this->name)) {
+            return $this->name;
+        }
+
+        if (isset($this->title)) {
+            return $this->title;
+        }
+
+        if (isset($this->label)) {
+            return $this->label;
+        }
+
+        return $this->id;
+    }
+
     public function logUpdate(): void
     {
         $diff = $this->getModelChangesJson(true); // true: If we want to limit the storage of fields defined in modelRelation; false : If we want to storage all model change
         $this->createActivityLog([
-            'title' => __('activity-log.actions.update').' #'.$this->id,
+            'title' => __('activity-log.actions.update').' #'.$this->activityLogEntityName(),
             'description' => $this->getModelChanges($diff),
         ]);
     }
@@ -137,7 +155,7 @@ trait ActivityLoggable
     public function logDelete(): void
     {
         $this->createActivityLog([
-            'title' => __('activity-log.actions.delete').' #'.$this->id,
+            'title' => __('activity-log.actions.delete').' #'.$this->activityLogEntityName(),
             'description' => '',
         ]);
     }


### PR DESCRIPTION
## key points 

- Added ability to by default use the entity name rather than the id which is not meaningful

## Screenshots

More meaningful than this

![image](https://github.com/DCODE-GROUP/laravel-activity-log/assets/832259/8f273419-486f-4b83-be5f-2e19a620147c)

