### PR TITLE
Ability to filter Activity Log by "id"

### DIFF
--- a/src/Http/Controllers/API/ActivityLogController.php
+++ b/src/Http/Controllers/API/ActivityLogController.php
@@ -24,6 +24,7 @@ class ActivityLogController extends Controller
             ])
             ->allowedFilters([
                 'created_by',
+                AllowedFilter::exact('id'),
                 AllowedFilter::exact('type'),
                 AllowedFilter::custom('date', new DateRangeFilter('created_at')),
                 AllowedFilter::custom('term', new TermFilter()),

--- a/src/Http/Requests/ExistingRequest.php
+++ b/src/Http/Requests/ExistingRequest.php
@@ -28,7 +28,6 @@ class ExistingRequest extends FormRequest
                 'string',
             ],
             'modelId' => [
-                'required',
                 'string',
                 Rule::exists($this->input('modelClass'), 'id'),
             ],

--- a/src/Http/Requests/ExistingRequest.php
+++ b/src/Http/Requests/ExistingRequest.php
@@ -28,7 +28,8 @@ class ExistingRequest extends FormRequest
                 'string',
             ],
             'modelId' => [
-                $this->has('filter.id') ? 'nullable' : 'required', // field is required when filter[id] is not present
+//                $this->has('filter.id') ? 'nullable' : 'required', // field is required when filter[id] is not present
+                'required_without:filter.id', // field is required when filter[id] is not present
                 'string',
                 Rule::exists($this->input('modelClass'), 'id'),
             ],

--- a/src/Http/Requests/ExistingRequest.php
+++ b/src/Http/Requests/ExistingRequest.php
@@ -28,6 +28,7 @@ class ExistingRequest extends FormRequest
                 'string',
             ],
             'modelId' => [
+                $this->request->has('filter[id]') ? 'nullable' : 'required', // field is required when filter[id] is not present
                 'string',
                 Rule::exists($this->input('modelClass'), 'id'),
             ],

--- a/src/Http/Requests/ExistingRequest.php
+++ b/src/Http/Requests/ExistingRequest.php
@@ -28,7 +28,7 @@ class ExistingRequest extends FormRequest
                 'string',
             ],
             'modelId' => [
-                $this->request->has('filter[id]') ? 'nullable' : 'required', // field is required when filter[id] is not present
+                $this->has('filter.id') ? 'nullable' : 'required', // field is required when filter[id] is not present
                 'string',
                 Rule::exists($this->input('modelClass'), 'id'),
             ],

--- a/src/Http/Requests/ExistingRequest.php
+++ b/src/Http/Requests/ExistingRequest.php
@@ -28,8 +28,7 @@ class ExistingRequest extends FormRequest
                 'string',
             ],
             'modelId' => [
-//                $this->has('filter.id') ? 'nullable' : 'required', // field is required when filter[id] is not present
-                'required_without:filter.id', // field is required when filter[id] is not present
+                'required_without:filter.id',
                 'string',
                 Rule::exists($this->input('modelClass'), 'id'),
             ],


### PR DESCRIPTION
Provides ability to filter Activity Logs by "id".

Because of this the `modelId` query is now only `required` when `filter[id]` query is not supplied.

Example GET request.

`/api/generic/activity-logs?modelClass=App\Models\Enquiry\Enquiry&filter[id]=1009`

Relates to: https://github.com/DCODE-GROUP/precision-scaffolding/pull/267