### PR TITLE
Remove requirement to specify every field to track or relationships 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ lists items that might need to run manually.
 
 ```php
     'exceptions' => [
-        'model_label' => 'No label has been found for :model',
+        'model_key' => 'No model key has been found for :model',
     ],
 
 ````

--- a/README.md
+++ b/README.md
@@ -409,6 +409,22 @@ public function getActivityLogModelLabel(): string
 }
 ```` 
 
+You can give any model a custom label by adding the following method to the model.
+ If this is not set then [Str::headline](https://laravel.com/docs/11.x/strings#method-str-headline) will be used on the model.
+
+
+```php
+public function getActivityLogModelLabel(): string
+{
+    /**
+      * This can be any field or method to return the label but the return must be a string 
+      */
+    return __('order.title');
+}
+```` 
+
+```php
+
 You can define the relationships for automatic labeling of associated models
 
 ** depreciated **

--- a/README.md
+++ b/README.md
@@ -423,6 +423,18 @@ public function getActivityLogModelLabel(): string
 }
 ```` 
 
+Automatically the package will try and find the key for the model. Typically, this will be a field named `name`, `title` or `label`. 
+However this may not always be the case and the key may change depending on the the state of a model. Eg type Quote might be `quote_number` Order might use `sales_order_number`.
+If one of the defaults is not found then an `ModelKeyNotDefinedException` exception will be thrown.
+
+This should only ever occur in your local environment. If this occurs then implement the follow method in your model.
+
+```php
+public function getActivityLogModelKey(): string
+{
+    return (string) $this->custom_field_name;
+}
+```
 
 You can use a custom formatter for fields in your model by using the `activityLogFieldFormatters` method.
 

--- a/README.md
+++ b/README.md
@@ -457,8 +457,6 @@ You can define the relationships for automatic labeling of associated models
     }
 ```
 
-
-
 You can use a custom formatter for fields in your model by using the `activityLogFieldFormatters` method.
 
 example. Add the following to the model

--- a/README.md
+++ b/README.md
@@ -423,39 +423,6 @@ public function getActivityLogModelLabel(): string
 }
 ```` 
 
-```php
-
-You can define the relationships for automatic labeling of associated models
-
-** depreciated **
-
-```php
- protected function modelRelation(): Collection
-    {
-        return collect([
-            'project_milestone_id' => collect([
-                'label' => __('project-milestone.headings.title'),
-                'modelClass' => ProjectMilestone::class,
-                'modelKey' => 'name',
-            ]),
-            'project_id' => collect([
-                'label' => __('project.headings.title'),
-                'modelClass' => Project::class,
-                'modelKey' => 'name',
-            ]),
-            'quote_type_id' => collect([
-                'label' => __('quote-type.headings.title'),
-                'modelClass' => QuoteType::class,
-                'modelKey' => 'name',
-            ]),
-            'client_id' => collect([
-                'label' => __('client.headings.title'),
-                'modelClass' => Client::class,
-                'modelKey' => 'name',
-            ]),
-        ]);
-    }
-```
 
 You can use a custom formatter for fields in your model by using the `activityLogFieldFormatters` method.
 

--- a/README.md
+++ b/README.md
@@ -436,6 +436,19 @@ public function getActivityLogModelKey(): string
 }
 ```
 
+By default this package will log all fields except for `created_at`, `updated_at`, `deleted_at`, `password`, and `id`.
+If you wish to exclude other fields on your model such as third party api tokens. Then implement the following method in your model.
+
+```php
+public function getActivityLogModelExcludeFields(): array
+{
+    return ['xero_api_token', 'stripe_api_token'];
+}
+```
+
+```php
+
+
 You can use a custom formatter for fields in your model by using the `activityLogFieldFormatters` method.
 
 example. Add the following to the model

--- a/lang/en/activity-log.php
+++ b/lang/en/activity-log.php
@@ -73,7 +73,7 @@ return [
     ],
 
     'exceptions' => [
-        'model_label' => 'No label has been found for :model',
+        'model_key' => 'No model key has been found for :model',
     ],
 
 ];

--- a/src/Events/FilterEvent.php
+++ b/src/Events/FilterEvent.php
@@ -11,8 +11,5 @@ class FilterEvent
     use Dispatchable;
     use SerializesModels;
 
-    public function __construct(public Builder $query, public $model)
-    {
-
-    }
+    public function __construct(public Builder $query, public $model) {}
 }

--- a/src/Exceptions/ModelKeyNotDefinedException.php
+++ b/src/Exceptions/ModelKeyNotDefinedException.php
@@ -4,6 +4,6 @@ namespace Dcodegroup\ActivityLog\Exceptions;
 
 use Exception;
 
-class ModelLabelNotDefinedException extends Exception
+class ModelKeyNotDefinedException extends Exception
 {
 }

--- a/src/Exceptions/ModelKeyNotDefinedException.php
+++ b/src/Exceptions/ModelKeyNotDefinedException.php
@@ -4,6 +4,4 @@ namespace Dcodegroup\ActivityLog\Exceptions;
 
 use Exception;
 
-class ModelKeyNotDefinedException extends Exception
-{
-}
+class ModelKeyNotDefinedException extends Exception {}

--- a/src/Http/Controllers/API/CommentController.php
+++ b/src/Http/Controllers/API/CommentController.php
@@ -9,9 +9,7 @@ use Illuminate\Routing\Controller;
 
 class CommentController extends Controller
 {
-    public function __construct(protected ActivityLogService $service)
-    {
-    }
+    public function __construct(protected ActivityLogService $service) {}
 
     public function __invoke(ExistingRequest $request)
     {

--- a/src/Http/Controllers/API/DeleteCommentController.php
+++ b/src/Http/Controllers/API/DeleteCommentController.php
@@ -8,9 +8,7 @@ use Illuminate\Routing\Controller;
 
 class DeleteCommentController extends Controller
 {
-    public function __construct(protected ActivityLogService $service)
-    {
-    }
+    public function __construct(protected ActivityLogService $service) {}
 
     public function __invoke(ActivityLog $comment)
     {

--- a/src/Http/Controllers/API/EditCommentController.php
+++ b/src/Http/Controllers/API/EditCommentController.php
@@ -9,9 +9,7 @@ use Illuminate\Routing\Controller;
 
 class EditCommentController extends Controller
 {
-    public function __construct(protected ActivityLogService $service)
-    {
-    }
+    public function __construct(protected ActivityLogService $service) {}
 
     public function __invoke(ActivityLog $comment, EditCommentRequest $request)
     {

--- a/src/Http/Controllers/API/ReadEmailController.php
+++ b/src/Http/Controllers/API/ReadEmailController.php
@@ -7,9 +7,7 @@ use Illuminate\Routing\Controller;
 
 class ReadEmailController extends Controller
 {
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     public function __invoke(ActivityLog $activityLog)
     {

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -255,6 +255,7 @@ trait ActivityLoggable
                 is_subclass_of($returnType, Relation::class) &&
                 $method->getName() == __FUNCTION__) {
 
+                ld('here');
                 $relationships[] = [
                     'method' => $method->getName(),
                     'relation' => $method->getReturnType(),

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -160,14 +160,14 @@ trait ActivityLoggable
         $relationships = [];
 
         foreach ((new ReflectionClass($model))->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
-            //            ld('model class: ', $method->class);
-            //            ld('class: ', get_class($model));
-            //            ld('method: ', $method);
-            //            ld('method name: '.$method->getName());
-            //            ld('is sub class of relation', is_subclass_of((string) $method->getReturnType(), Relation::class));
-            //            //            ld('params: ', $method->getParameters());
-            //            ld('return type: ', $method->getReturnType());
-            //            ld('getname is function ', ($method->getName() == __FUNCTION__));
+            ld('model class: ', $method->class);
+            ld('class: ', get_class($model));
+            ld('method: ', $method);
+            ld('method name: '.$method->getName());
+            ld('is sub class of relation', is_subclass_of((string) $method->getReturnType(), Relation::class));
+            //            ld('params: ', $method->getParameters());
+            ld('return type: ', $method->getReturnType());
+            ld('getname is function ', ($method->getName() == __FUNCTION__));
             if (
                 ! empty($method->getReturnType()) &&
                 is_subclass_of((string) $method->getReturnType(), Relation::class)

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -262,6 +262,8 @@ trait ActivityLoggable
                         'type' => (new ReflectionClass($return))->getShortName(),
                         'model' => (new ReflectionClass($return->getRelated()))->getName(),
                     ];
+
+                    ld('getModelRelationships relationship', $relationships);
                 }
             } catch (Exception $e) {
                 report($e);

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -191,7 +191,7 @@ trait ActivityLoggable
             ld('method name: '.$method->getName());
             ld('params: ', $method->getParameters());
             if ($method->class != get_class($model) ||
-                ! empty($method->getParameters()) ||
+//                ! empty($method->getParameters()) ||
                 $method->getName() == __FUNCTION__) {
                 continue;
             }

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -149,7 +149,7 @@ trait ActivityLoggable
                 $from = $modelClass && $modelClass::find($from) ? $modelClass::find($from)->determineModelLabel() : '+';
                 $to = $modelClass && $modelClass::find($to) ? $modelClass::find($to)->determineModelLabel() : '+';
 
-                $key = $entity['label'];
+                $key = $modelClass::find($from)->determineModelLabel();
             }
             ////            $modelClass = array_flip($this->getActivityLogModelRelationFields())[$attribute];
             //            $from = $modelClass && $modelClass::find($from) ? $modelClass::find($from)->{$entity['modelKey']} : '+';
@@ -200,7 +200,6 @@ trait ActivityLoggable
 
     public function determineModelLabel(): string
     {
-
         /**
          * check if we have the model label in cache
          */

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -185,26 +185,16 @@ trait ActivityLoggable
     public function determineModelKey(): string
     {
         /**
-         * check if we have the model label in cache
-         */
-        //        if (Cache::has('model_key_'.class_basename($this))) {
-        //            return Cache::get('model_key_'.class_basename($this));
-        //        }
-
-        /**
          * Check if the label has been set in the model
          */
         if (! empty($this->getActivityLogModelKey())) {
             return $this->getActivityLogModelKey();
-
-            //            return Cache::rememberForever('model_key_'.class_basename($this), fn () => $this->getActivityLogModelKey());
         }
 
         $standardKeys = ['name', 'title', 'label'];
 
         foreach ($standardKeys as $key) {
             if (collect($this->getAttributes())->has($key)) {
-                //                return Cache::rememberForever('model_key_'.class_basename($this), fn () => $this->{$key});
                 return $this->{$key};
             }
         }

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -160,7 +160,7 @@ trait ActivityLoggable
                     'method' => $method->getName(),
                     'relation' => $method->getReturnType()->getName(),
                     'foreignKey' => method_exists($model->{$method->getName()}(), 'getForeignKeyName') ? $model->{$method->getName()}()->getForeignKeyName() : $model->{$method->getName()}()->getForeignPivotKeyName(),
-                    'localKey' => method_exists($model->{$method->getName()}(), 'getOwnerKeyName') ? $model->{$method->getName()}()->getOwnerKeyName() : $model->{$method->getName()}()->getLocalKeyName(),
+                    'localKey' => method_exists($model->{$method->getName()}(), 'getOwnerKeyName') ? $model->{$method->getName()}()->getOwnerKeyName() : ($model->{$method->getName()}()->getLocalKeyName() ?: $model->{$method->getName()}()->getRelatedPivotKeyName()),
                     'modelClass' => $model->{$method->getName()}()->getRelated(),
                 ];
             }

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -219,7 +219,7 @@ trait ActivityLoggable
 
         ld('got here should throw exception');
 
-        throw new ModelKeyNotDefinedException(__('activity-log.exceptions.model_key_not_defined', ['model' => class_basename($this)]));
+        throw new ModelKeyNotDefinedException(__('activity-log.exceptions.model_key', ['model' => class_basename($this)]));
     }
 
     public function getActivityLogModelKey(): string

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -159,7 +159,7 @@ trait ActivityLoggable
                 $relationships[] = [
                     'method' => $method->getName(),
                     'relation' => $method->getReturnType()->getName(),
-                    'foreignKey' => $model->{$method->getName()}()->getForeignKeyName(),
+                    'foreignKey' => method_exists($model->{$method->getName()}(), 'getForeignKeyName') ? $model->{$method->getName()}()->getForeignKeyName() : $model->{$method->getName()}()->getForeignPivotKeyName(),
                     'localKey' => method_exists($model->{$method->getName()}(), 'getOwnerKeyName') ? $model->{$method->getName()}()->getOwnerKeyName() : $model->{$method->getName()}()->getLocalKeyName(),
                     'modelClass' => $model->{$method->getName()}()->getRelated(),
                 ];

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -264,7 +264,7 @@ trait ActivityLoggable
                 //                dd($model->{$method->getName()}());
                 $relationships[] = [
                     'method' => $method->getName(),
-                    'relation' => $method->getReturnType(),
+                    'relation' => $method->getReturnType()->getName(),
                     'foreignKeys' => $model->{$method->getName()}()->getForeignKeyName(),
                     'localKey' => method_exists($model->{$method->getName()}(), 'getOwnerKeyName') ? $model->{$method->getName()}()->getOwnerKeyName() : $model->{$method->getName()}()->getLocalKeyName(),
                 ];

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -188,7 +188,7 @@ trait ActivityLoggable
 
         foreach ((new ReflectionClass($model))->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
             ld('method: ', $method);
-            ld('method name: ', $method->getName());
+            ld('method name: '.$method->getName());
             ld('params: ', $method->getParameters());
             if ($method->class != get_class($model) ||
                 ! empty($method->getParameters()) ||

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -261,11 +261,12 @@ trait ActivityLoggable
             ) {
 
                 ld('here');
+                //                dd($model->{$method->getName()}());
                 $relationships[] = [
                     'method' => $method->getName(),
                     'relation' => $method->getReturnType(),
-                    'foreignKeys' => $model->{$method->getName()}()->getForeignKey(),
-                    'localKey' => $model->{$method->getName()}()->getKeyName(),
+                    'foreignKeys' => $model->{$method->getName()}()->getForeignKeyName(),
+                    'localKey' => $model->{$method->getName()}()->getLocalKeyName(),
                 ];
 
             }

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -197,7 +197,7 @@ trait ActivityLoggable
             }
 
             try {
-                $return = $method->invoke($model);
+                $return = $method->invoke($model, $method->getParameters());
                 //                ld('return: ', $return);
 
                 if ($return instanceof Relation) {

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -167,7 +167,7 @@ trait ActivityLoggable
 
         //        ld('available relations', $this->getAvailableRelations());
 
-        ld('model relationship', $this->getModelRelationships());
+        //        ld('model relationship', $this->getModelRelationships());
 
         //        $baseClass = get_class($this);
         //        ld('base class: '.$baseClass);
@@ -190,6 +190,7 @@ trait ActivityLoggable
             //            ld('method: ', $method);
             //            ld('method name: '.$method->getName());
             //            ld('params: ', $method->getParameters());
+            ld('return type: ', $method->getReturnType());
             if ($method->class != get_class($model) ||
 //                ! empty($method->getParameters()) ||
                 $method->getName() == __FUNCTION__) {

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -184,7 +184,7 @@ trait ActivityLoggable
                     'foreignKey' => $model->{$method->getName()}()->getForeignKeyName(),
                     'localKey' => method_exists($model->{$method->getName()}(), 'getOwnerKeyName') ? $model->{$method->getName()}()->getOwnerKeyName() : $model->{$method->getName()}()->getLocalKeyName(),
                     'modelClass' => $method->class,
-                    'currentModel' => $model,
+                    //                    'currentModel' => $model,
                 ];
             }
         }

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -137,7 +137,6 @@ trait ActivityLoggable
         $key = $attribute;
 
         ld('$attribute: '.$attribute);
-        ld('model relationship', $this->getModelRelationships());
         ld('model relation fields:', $this->getActivityLogModelRelationFields());
 
         //     getActivityLogModelRelationFields()
@@ -162,6 +161,26 @@ trait ActivityLoggable
         ];
     }
 
+    public function getActivityLogModelRelationFields(): array
+    {
+        //        ld('relations: ', self::$availableRelations);
+
+        //        ld('available relations', $this->getAvailableRelations());
+
+        ld('model relationship', $this->getModelRelationships());
+
+        //        $baseClass = get_class($this);
+        //        ld('base class: '.$baseClass);
+        //        //        ld('relations', (new $baseClass())->getRelations());
+        //        ld('relations', $this->getRelations());
+        //        ld('this', $this);
+
+        //        return collect($this->getAvailableRelations())->keys()->filter(fn ($relationName) => $this->{$relationName}() instanceof BelongsTo)->mapWithKeys(fn ($item) => [$item => $this->{$item}->getForeignKey()])->toArray();
+        return collect($this->getRelations())->keys()->filter(fn ($relationName) => $this->{$relationName}() instanceof BelongsTo)->mapWithKeys(fn ($item) => [$item => $this->{$item}->getForeignKey()])->toArray();
+        // when ready cache this
+        //        return Cache::rememberForever('model_relations_'.self::class, fn () => collect($this->getRelations())->keys()->filter(fn ($relationName) => $this->{$relationName}() instanceof BelongsTo)->mapWithKeys(fn ($item) => [$item => $this->{$item}->getForeignKey()])->toArray());
+    }
+
     public function getModelRelationships()
     {
         $model = new static();
@@ -184,30 +203,12 @@ trait ActivityLoggable
                     ];
                 }
             } catch (Exception $e) {
+                report($e);
+                ld('something went wrong');
             }
         }
 
         return $relationships;
-    }
-
-    public function getActivityLogModelRelationFields(): array
-    {
-        //        ld('relations: ', self::$availableRelations);
-
-        //        ld('available relations', $this->getAvailableRelations());
-
-        ld('model relationship', $this->getModelRelationships());
-
-        //        $baseClass = get_class($this);
-        //        ld('base class: '.$baseClass);
-        //        //        ld('relations', (new $baseClass())->getRelations());
-        //        ld('relations', $this->getRelations());
-        //        ld('this', $this);
-
-        //        return collect($this->getAvailableRelations())->keys()->filter(fn ($relationName) => $this->{$relationName}() instanceof BelongsTo)->mapWithKeys(fn ($item) => [$item => $this->{$item}->getForeignKey()])->toArray();
-        return collect($this->getRelations())->keys()->filter(fn ($relationName) => $this->{$relationName}() instanceof BelongsTo)->mapWithKeys(fn ($item) => [$item => $this->{$item}->getForeignKey()])->toArray();
-        // when ready cache this
-        //        return Cache::rememberForever('model_relations_'.self::class, fn () => collect($this->getRelations())->keys()->filter(fn ($relationName) => $this->{$relationName}() instanceof BelongsTo)->mapWithKeys(fn ($item) => [$item => $this->{$item}->getForeignKey()])->toArray());
     }
 
     public function getModelChanges(?array $modelChangesJson = null): string

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -266,7 +266,7 @@ trait ActivityLoggable
                     'method' => $method->getName(),
                     'relation' => $method->getReturnType(),
                     'foreignKeys' => $model->{$method->getName()}()->getForeignKeyName(),
-                    'localKey' => $model->{$method->getName()}()->getOwnerKeyName() ?: $model->{$method->getName()}()->getLocalKeyName(),
+                    'localKey' => method_exists($model->{$method->getName()}(), 'getOwnerKeyName') ? $model->{$method->getName()}()->getOwnerKeyName() : $model->{$method->getName()}()->getLocalKeyName(),
                 ];
 
             }

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -98,8 +98,8 @@ trait ActivityLoggable
                     $new = $formatter($new);
                 }
 
-                $from = is_array($original) ? collect($original)->map(fn ($item) => is_string($item) ? $item : new StringConverter($item))->join('|') : $original;
-                $to = is_array($new) ? collect($new)->map(fn ($item) => is_string($item) ? $item : new StringConverter($item))->join('|') : (is_string($new) ? $new : new StringConverter($this->{$attribute}));
+                $from = $this->formatValue($original);
+                $to = $this->formatValue($new);
 
                 return $this->prepareModelChange($attribute, $from, $to);
             })->toArray();
@@ -121,6 +121,17 @@ trait ActivityLoggable
     protected function activityLogFieldFormatters(): Collection
     {
         return collect([]);
+    }
+
+    private function formatValue($value)
+    {
+        if (is_array($value)) {
+            return collect($value)
+                ->map(fn ($item) => is_string($item) ? $item : new StringConverter($item))
+                ->join('|');
+        }
+
+        return is_string($value) ? $value : new StringConverter($value);
     }
 
     public function prepareModelChange($attribute, $from, $to): array

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -175,13 +175,13 @@ trait ActivityLoggable
                 ! empty($method->getReturnType()) &&
                 is_subclass_of((string) $method->getReturnType(), Relation::class)
             ) {
-
+                //                dd($method);
                 $relationships[] = [
                     'method' => $method->getName(),
                     'relation' => $method->getReturnType()->getName(),
                     'foreignKey' => $model->{$method->getName()}()->getForeignKeyName(),
                     'localKey' => method_exists($model->{$method->getName()}(), 'getOwnerKeyName') ? $model->{$method->getName()}()->getOwnerKeyName() : $model->{$method->getName()}()->getLocalKeyName(),
-                    'modelClass' => $method->class,
+                    'modelClass' => $model->{$method->getName()}()->getRelated(),
                     //                    'currentModel' => $model,
                 ];
             }

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -163,13 +163,19 @@ trait ActivityLoggable
                     $foreignKey = $model->{$method->getName()}()->getForeignPivotKeyName();
                 }
 
-                if (method_exists($model->{$method->getName()}(), 'getOwnerKeyName')) {
-                    $localKey = $model->{$method->getName()}()->getOwnerKeyName();
-                } elseif (method_exists($model->{$method->getName()}(), 'getLocalKeyName')) {
-                    $localKey = $model->{$method->getName()}()->getLocalKeyName();
-                } else {
-                    $localKey = $model->{$method->getName()}()->getRelatedPivotKeyName();
-                }
+                //                if (method_exists($model->{$method->getName()}(), 'getOwnerKeyName')) {
+                //                    $localKey = $model->{$method->getName()}()->getOwnerKeyName();
+                //                } elseif (method_exists($model->{$method->getName()}(), 'getLocalKeyName')) {
+                //                    $localKey = $model->{$method->getName()}()->getLocalKeyName();
+                //                } else {
+                //                    $localKey = $model->{$method->getName()}()->getRelatedPivotKeyName();
+                //                }
+
+                $localKey = match (true) {
+                    method_exists($model->{$method->getName()}(), 'getOwnerKeyName') => $model->{$method->getName()}()->getOwnerKeyName(),
+                    method_exists($model->{$method->getName()}(), 'getLocalKeyName') => $model->{$method->getName()}()->getLocalKeyName(),
+                    default => $model->{$method->getName()}()->getRelatedPivotKeyName(),
+                };
 
                 $relationships[] = [
                     'method' => $method->getName(),

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -167,7 +167,7 @@ trait ActivityLoggable
 
         //        ld('available relations', $this->getAvailableRelations());
 
-        //        ld('model relationship', $this->getModelRelationships());
+        ld('model relationship', $this->getModelRelationships());
 
         //        $baseClass = get_class($this);
         //        ld('base class: '.$baseClass);

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -135,13 +135,14 @@ trait ActivityLoggable
         $key = $attribute;
 
         ld('$attribute: '.$attribute);
-        ld('model relation fields:', $this->getActivityLogModelRelationFields());
+        //        ld('model relation fields:', $this->getActivityLogModelRelationFields());
 
         //     getActivityLogModelRelationFields()
 
         if (in_array($attribute, collect($this->getActivityLogModelRelationFields())->pluck('foreignKey')->toArray())) {
 
-            //            $modelClass = array_flip($this->getActivityLogModelRelationFields())[$attribute];
+            //            $modelClass = collect($this->getActivityLogModelRelationFields())
+            ////            $modelClass = array_flip($this->getActivityLogModelRelationFields())[$attribute];
             //            $from = $modelClass && $modelClass::find($from) ? $modelClass::find($from)->{$entity['modelKey']} : '+';
             //            $to = $modelClass && $modelClass::find($to) ? $modelClass::find($to)->{$entity['modelKey']} : '+';
             //

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -157,25 +157,11 @@ trait ActivityLoggable
                 is_subclass_of((string) $method->getReturnType(), Relation::class)
             ) {
 
-                //                if (method_exists($model->{$method->getName()}(), 'getForeignKeyName')) {
-                //                    $foreignKey = $model->{$method->getName()}()->getForeignKeyName();
-                //                } else {
-                //                    $foreignKey = $model->{$method->getName()}()->getForeignPivotKeyName();
-                //                }
-
                 $relationMethod = $model->{$method->getName()}();
                 $foreignKey = match (true) {
                     method_exists($relationMethod, 'getForeignKeyName') => $relationMethod->getForeignKeyName(),
                     default => $relationMethod->getForeignPivotKeyName(),
                 };
-
-                //                if (method_exists($model->{$method->getName()}(), 'getOwnerKeyName')) {
-                //                    $localKey = $model->{$method->getName()}()->getOwnerKeyName();
-                //                } elseif (method_exists($model->{$method->getName()}(), 'getLocalKeyName')) {
-                //                    $localKey = $model->{$method->getName()}()->getLocalKeyName();
-                //                } else {
-                //                    $localKey = $model->{$method->getName()}()->getRelatedPivotKeyName();
-                //                }
 
                 $localKey = match (true) {
                     method_exists($relationMethod, 'getOwnerKeyName') => $relationMethod->getOwnerKeyName(),
@@ -201,22 +187,25 @@ trait ActivityLoggable
         /**
          * check if we have the model label in cache
          */
-        if (Cache::has('model_key_'.class_basename($this))) {
-            return Cache::get('model_key_'.class_basename($this));
-        }
+        //        if (Cache::has('model_key_'.class_basename($this))) {
+        //            return Cache::get('model_key_'.class_basename($this));
+        //        }
 
         /**
          * Check if the label has been set in the model
          */
         if (! empty($this->getActivityLogModelKey())) {
-            return Cache::rememberForever('model_key_'.class_basename($this), fn () => $this->getActivityLogModelKey());
+            return $this->getActivityLogModelKey();
+
+            //            return Cache::rememberForever('model_key_'.class_basename($this), fn () => $this->getActivityLogModelKey());
         }
 
         $standardKeys = ['name', 'title', 'label'];
 
         foreach ($standardKeys as $key) {
             if (collect($this->getAttributes())->has($key)) {
-                return Cache::rememberForever('model_key_'.class_basename($this), fn () => $this->{$key});
+                //                return Cache::rememberForever('model_key_'.class_basename($this), fn () => $this->{$key});
+                return $this->{$key};
             }
         }
 

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -163,10 +163,10 @@ trait ActivityLoggable
         $relationships = [];
 
         foreach ((new ReflectionClass($model))->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
-            ld('model class: ', $method->class);
-            ld('class: ', get_class($model));
-            ld('method: ', $method);
-            ld('method name: '.$method->getName());
+            //            ld('model class: ', $method->class);
+            //            ld('class: ', get_class($model));
+            //            ld('method: ', $method);
+            //            ld('method name: '.$method->getName());
             //            ld('is sub class of relation', is_subclass_of((string) $method->getReturnType(), Relation::class));
             //            //            ld('params: ', $method->getParameters());
             //            ld('return type: ', $method->getReturnType());
@@ -175,7 +175,6 @@ trait ActivityLoggable
                 ! empty($method->getReturnType()) &&
                 is_subclass_of((string) $method->getReturnType(), Relation::class)
             ) {
-                //                dd($method);
                 $relationships[] = [
                     'method' => $method->getName(),
                     'relation' => $method->getReturnType()->getName(),

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -161,14 +161,14 @@ trait ActivityLoggable
         $relationships = [];
 
         foreach ((new ReflectionClass($model))->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
-            ld('model class: ', $method->class);
-            ld('class: ', get_class($model));
-            ld('method: ', $method);
-            ld('method name: '.$method->getName());
-            ld('is sub class of relation', is_subclass_of((string) $method->getReturnType(), Relation::class));
-            //            ld('params: ', $method->getParameters());
-            ld('return type: ', $method->getReturnType());
-            ld('getname is function ', ($method->getName() == __FUNCTION__));
+            //            ld('model class: ', $method->class);
+            //            ld('class: ', get_class($model));
+            //            ld('method: ', $method);
+            //            ld('method name: '.$method->getName());
+            //            ld('is sub class of relation', is_subclass_of((string) $method->getReturnType(), Relation::class));
+            //            //            ld('params: ', $method->getParameters());
+            //            ld('return type: ', $method->getReturnType());
+            //            ld('getname is function ', ($method->getName() == __FUNCTION__));
             if (
                 ! empty($method->getReturnType()) &&
                 is_subclass_of((string) $method->getReturnType(), Relation::class)

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -107,7 +107,7 @@ trait ActivityLoggable
 
     public function getActivityLogModelAttributes(): Collection
     {
-        return collect(array_merge($this->getAttributes(), ['created_at', 'updated_at', 'deleted_at'], $this->getActivityLogModelExcludeFields()));
+        return collect(array_merge($this->getAttributes(), ['created_at', 'updated_at', 'deleted_at', 'id', 'password'], $this->getActivityLogModelExcludeFields()));
     }
 
     /**

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -157,11 +157,25 @@ trait ActivityLoggable
                 is_subclass_of((string) $method->getReturnType(), Relation::class)
             ) {
 
+                if (method_exists($model->{$method->getName()}(), 'getForeignKeyName')) {
+                    $foreignKey = $model->{$method->getName()}()->getForeignKeyName();
+                } else {
+                    $foreignKey = $model->{$method->getName()}()->getForeignPivotKeyName();
+                }
+
+                if (method_exists($model->{$method->getName()}(), 'getOwnerKeyName')) {
+                    $localKey = $model->{$method->getName()}()->getOwnerKeyName();
+                } elseif (method_exists($model->{$method->getName()}(), 'getLocalKeyName')) {
+                    $localKey = $model->{$method->getName()}()->getLocalKeyName();
+                } else {
+                    $localKey = $model->{$method->getName()}()->getRelatedPivotKeyName();
+                }
+
                 $relationships[] = [
                     'method' => $method->getName(),
                     'relation' => $method->getReturnType()->getName(),
-                    'foreignKey' => method_exists($model->{$method->getName()}(), 'getForeignKeyName') ? $model->{$method->getName()}()->getForeignKeyName() : $model->{$method->getName()}()->getForeignPivotKeyName(),
-                    'localKey' => method_exists($model->{$method->getName()}(), 'getOwnerKeyName') ? $model->{$method->getName()}()->getOwnerKeyName() : ($model->{$method->getName()}()->getLocalKeyName() ?: $model->{$method->getName()}()->getRelatedPivotKeyName()),
+                    'foreignKey' => $foreignKey,
+                    'localKey' => $localKey,
                     'modelClass' => $model->{$method->getName()}()->getRelated(),
                 ];
             }

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -125,7 +125,7 @@ trait ActivityLoggable
 
     public function prepareModelChange($attribute, $from, $to): array
     {
-        ld('attribute', $attribute);
+        ld('attribute: '.$attribute);
         ld('from', $from);
         ld('to', $to);
 
@@ -140,8 +140,10 @@ trait ActivityLoggable
             if (! empty($relation)) {
                 //            $modelClass = array_flip($this->getActivityLogModelRelationFields())[$attribute];
                 $modelClass = $relation['modelClass'];
-                $from = $modelClass && $modelClass::find($from) ? $modelClass::find($from)->determineModelKey() : '+';
-                $to = $modelClass && $modelClass::find($to) ? $modelClass::find($to)->determineModelKey() : '+';
+                ld('model class: '.$modelClass);
+                ld('find from', $modelClass::find($from));
+                $from = $modelClass && $modelClass::find($from) ? ($modelClass::find($from))->determineModelKey() : '+';
+                $to = $modelClass && $modelClass::find($to) ? ($modelClass::find($to))->determineModelKey() : '+';
 
                 //                $key = $modelClass::find($from)->determineModelLabel();
                 $key = (new $modelClass())->determineModelLabel();

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -266,7 +266,7 @@ trait ActivityLoggable
                     'method' => $method->getName(),
                     'relation' => $method->getReturnType(),
                     'foreignKeys' => $model->{$method->getName()}()->getForeignKeyName(),
-                    'localKey' => $model->{$method->getName()}()->getOwnerKeyName() ?? $model->{$method->getName()}()->getLocalKeyName(),
+                    'localKey' => $model->{$method->getName()}()->getOwnerKeyName() ?: $model->{$method->getName()}()->getLocalKeyName(),
                 ];
 
             }

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -19,13 +19,6 @@ use ReflectionMethod;
 
 trait ActivityLoggable
 {
-    /**
-     * Available relationships for the model.
-     *
-     * @var array
-     */
-    protected static $availableRelations = [];
-
     public static function bootActivityLoggable()
     {
         static::created(function ($model) {

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -157,11 +157,17 @@ trait ActivityLoggable
                 is_subclass_of((string) $method->getReturnType(), Relation::class)
             ) {
 
-                if (method_exists($model->{$method->getName()}(), 'getForeignKeyName')) {
-                    $foreignKey = $model->{$method->getName()}()->getForeignKeyName();
-                } else {
-                    $foreignKey = $model->{$method->getName()}()->getForeignPivotKeyName();
-                }
+                //                if (method_exists($model->{$method->getName()}(), 'getForeignKeyName')) {
+                //                    $foreignKey = $model->{$method->getName()}()->getForeignKeyName();
+                //                } else {
+                //                    $foreignKey = $model->{$method->getName()}()->getForeignPivotKeyName();
+                //                }
+
+                $relationMethod = $model->{$method->getName()}();
+                $foreignKey = match (true) {
+                    method_exists($relationMethod, 'getForeignKeyName') => $relationMethod->getForeignKeyName(),
+                    default => $relationMethod->getForeignPivotKeyName(),
+                };
 
                 //                if (method_exists($model->{$method->getName()}(), 'getOwnerKeyName')) {
                 //                    $localKey = $model->{$method->getName()}()->getOwnerKeyName();

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -137,6 +137,7 @@ trait ActivityLoggable
         if (in_array($attribute, collect($this->getActivityLogModelRelationFields())->pluck('foreignKey')->toArray())) {
 
             $relation = collect($this->getActivityLogModelRelationFields())->where('foreignKey', $attribute)->first();
+            ld('relation', $relation);
 
             if (! empty($relation)) {
                 //            $modelClass = array_flip($this->getActivityLogModelRelationFields())[$attribute];

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -178,9 +178,9 @@ trait ActivityLoggable
                 //                }
 
                 $localKey = match (true) {
-                    method_exists($model->{$method->getName()}(), 'getOwnerKeyName') => $model->{$method->getName()}()->getOwnerKeyName(),
-                    method_exists($model->{$method->getName()}(), 'getLocalKeyName') => $model->{$method->getName()}()->getLocalKeyName(),
-                    default => $model->{$method->getName()}()->getRelatedPivotKeyName(),
+                    method_exists($relationMethod, 'getOwnerKeyName') => $relationMethod->getOwnerKeyName(),
+                    method_exists($relationMethod, 'getLocalKeyName') => $relationMethod->getLocalKeyName(),
+                    default => $relationMethod->getRelatedPivotKeyName(),
                 };
 
                 $relationships[] = [

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -252,11 +252,11 @@ trait ActivityLoggable
             //            ld('params: ', $method->getParameters());
             ld('return type: ', $method->getReturnType());
             ld('getname is function ', ($method->getName() == __FUNCTION__));
-            if ($method->class != get_class($model) &&
-//                ! empty($method->getParameters()) ||
+            if (
+                //                $method->class != get_class($model) &&
+                //                ! empty($method->getParameters()) ||
                 ! empty($method->getReturnType()) &&
-                ($returnType = (string) $method->getReturnType()) &&
-                is_subclass_of($returnType, Relation::class)
+                is_subclass_of((string) $method->getReturnType(), Relation::class)
                 //                ($method->getName() == __FUNCTION__)
             ) {
 

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -253,40 +253,17 @@ trait ActivityLoggable
             ld('return type: ', $method->getReturnType());
             ld('getname is function ', ($method->getName() == __FUNCTION__));
             if (
-                //                $method->class != get_class($model) &&
-                //                ! empty($method->getParameters()) ||
                 ! empty($method->getReturnType()) &&
                 is_subclass_of((string) $method->getReturnType(), Relation::class)
-                //                ($method->getName() == __FUNCTION__)
             ) {
 
-                ld('here');
-                //                dd($model->{$method->getName()}());
                 $relationships[] = [
                     'method' => $method->getName(),
                     'relation' => $method->getReturnType()->getName(),
                     'foreignKeys' => $model->{$method->getName()}()->getForeignKeyName(),
                     'localKey' => method_exists($model->{$method->getName()}(), 'getOwnerKeyName') ? $model->{$method->getName()}()->getOwnerKeyName() : $model->{$method->getName()}()->getLocalKeyName(),
                 ];
-
             }
-
-            //            try {
-            //                $return = $method->invoke($model, $method->getParameters());
-            //                //                ld('return: ', $return);
-            //
-            //                if ($return instanceof Relation) {
-            //                    $relationships[$method->getName()] = [
-            //                        'type' => (new ReflectionClass($return))->getShortName(),
-            //                        'model' => (new ReflectionClass($return->getRelated()))->getName(),
-            //                    ];
-            //
-            //                    //                    ld('getModelRelationships relationship', $relationships);
-            //                }
-            //            } catch (Exception $e) {
-            //                report($e);
-            //                ld('something went wrong');
-            //            }
         }
 
         return $relationships;

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -141,11 +141,11 @@ trait ActivityLoggable
 
         if (in_array($attribute, collect($this->getActivityLogModelRelationFields())->pluck('foreignKey')->toArray())) {
 
-//            $modelClass = array_flip($this->getActivityLogModelRelationFields())[$attribute];
-//            $from = $modelClass && $modelClass::find($from) ? $modelClass::find($from)->{$entity['modelKey']} : '+';
-//            $to = $modelClass && $modelClass::find($to) ? $modelClass::find($to)->{$entity['modelKey']} : '+';
-//
-//            $key = $entity['label'];
+            //            $modelClass = array_flip($this->getActivityLogModelRelationFields())[$attribute];
+            //            $from = $modelClass && $modelClass::find($from) ? $modelClass::find($from)->{$entity['modelKey']} : '+';
+            //            $to = $modelClass && $modelClass::find($to) ? $modelClass::find($to)->{$entity['modelKey']} : '+';
+            //
+            //            $key = $entity['label'];
         }
         //
         //        if ($entity = $this->modelRelation()->get($attribute)) {
@@ -165,14 +165,14 @@ trait ActivityLoggable
         $relationships = [];
 
         foreach ((new ReflectionClass($model))->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
-                        ld('model class: ', $method->class);
-                        ld('class: ', get_class($model));
-                        ld('method: ', $method);
-                        ld('method name: '.$method->getName());
-                        ld('is sub class of relation', is_subclass_of((string) $method->getReturnType(), Relation::class));
-                        //            ld('params: ', $method->getParameters());
-                        ld('return type: ', $method->getReturnType());
-                        ld('getname is function ', ($method->getName() == __FUNCTION__));
+            ld('model class: ', $method->class);
+            ld('class: ', get_class($model));
+            ld('method: ', $method);
+            ld('method name: '.$method->getName());
+            ld('is sub class of relation', is_subclass_of((string) $method->getReturnType(), Relation::class));
+            //            ld('params: ', $method->getParameters());
+            ld('return type: ', $method->getReturnType());
+            ld('getname is function ', ($method->getName() == __FUNCTION__));
             if (
                 ! empty($method->getReturnType()) &&
                 is_subclass_of((string) $method->getReturnType(), Relation::class)
@@ -183,7 +183,7 @@ trait ActivityLoggable
                     'relation' => $method->getReturnType()->getName(),
                     'foreignKey' => $model->{$method->getName()}()->getForeignKeyName(),
                     'localKey' => method_exists($model->{$method->getName()}(), 'getOwnerKeyName') ? $model->{$method->getName()}()->getOwnerKeyName() : $model->{$method->getName()}()->getLocalKeyName(),
-                    'modelClass' => ,
+                    'modelClass' => '',
                 ];
             }
         }

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -209,6 +209,8 @@ trait ActivityLoggable
 
         foreach ($standardKeys as $key) {
             if (collect($this->getAttributes())->has($key)) {
+                ld('has key : '.$key);
+
                 return Cache::rememberForever('model_key_'.class_basename($this), fn () => $this->{$key});
             }
         }

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -183,7 +183,8 @@ trait ActivityLoggable
                     'relation' => $method->getReturnType()->getName(),
                     'foreignKey' => $model->{$method->getName()}()->getForeignKeyName(),
                     'localKey' => method_exists($model->{$method->getName()}(), 'getOwnerKeyName') ? $model->{$method->getName()}()->getOwnerKeyName() : $model->{$method->getName()}()->getLocalKeyName(),
-                    'modelClass' => '',
+                    'modelClass' => $method->class,
+                    'currentModel' => $model,
                 ];
             }
         }

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -134,11 +134,6 @@ trait ActivityLoggable
     {
         $key = $attribute;
 
-        ld('$attribute: '.$attribute);
-        //        ld('model relation fields:', $this->getActivityLogModelRelationFields());
-
-        //     getActivityLogModelRelationFields()
-
         if (in_array($attribute, collect($this->getActivityLogModelRelationFields())->pluck('foreignKey')->toArray())) {
 
             $relation = collect($this->getActivityLogModelRelationFields())->where('foreignKey', $attribute)->first();
@@ -151,11 +146,6 @@ trait ActivityLoggable
 
                 $key = $modelClass::find($from)->determineModelLabel();
             }
-            ////            $modelClass = array_flip($this->getActivityLogModelRelationFields())[$attribute];
-            //            $from = $modelClass && $modelClass::find($from) ? $modelClass::find($from)->{$entity['modelKey']} : '+';
-            //            $to = $modelClass && $modelClass::find($to) ? $modelClass::find($to)->{$entity['modelKey']} : '+';
-            //
-            //            $key = $entity['label'];
         }
 
         return [
@@ -171,14 +161,14 @@ trait ActivityLoggable
         $relationships = [];
 
         foreach ((new ReflectionClass($model))->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
-            ld('model class: ', $method->class);
-            ld('class: ', get_class($model));
-            ld('method: ', $method);
-            ld('method name: '.$method->getName());
-            ld('is sub class of relation', is_subclass_of((string) $method->getReturnType(), Relation::class));
-            //            ld('params: ', $method->getParameters());
-            ld('return type: ', $method->getReturnType());
-            ld('getname is function ', ($method->getName() == __FUNCTION__));
+            //            ld('model class: ', $method->class);
+            //            ld('class: ', get_class($model));
+            //            ld('method: ', $method);
+            //            ld('method name: '.$method->getName());
+            //            ld('is sub class of relation', is_subclass_of((string) $method->getReturnType(), Relation::class));
+            //            //            ld('params: ', $method->getParameters());
+            //            ld('return type: ', $method->getReturnType());
+            //            ld('getname is function ', ($method->getName() == __FUNCTION__));
             if (
                 ! empty($method->getReturnType()) &&
                 is_subclass_of((string) $method->getReturnType(), Relation::class)
@@ -328,8 +318,8 @@ trait ActivityLoggable
         ]);
     }
 
-    protected function modelRelation(): Collection
-    {
-        return collect([]);
-    }
+    //    protected function modelRelation(): Collection
+    //    {
+    //        return collect([]);
+    //    }
 }

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -163,10 +163,10 @@ trait ActivityLoggable
         $relationships = [];
 
         foreach ((new ReflectionClass($model))->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
-            //            ld('model class: ', $method->class);
-            //            ld('class: ', get_class($model));
-            //            ld('method: ', $method);
-            //            ld('method name: '.$method->getName());
+            ld('model class: ', $method->class);
+            ld('class: ', get_class($model));
+            ld('method: ', $method);
+            ld('method name: '.$method->getName());
             //            ld('is sub class of relation', is_subclass_of((string) $method->getReturnType(), Relation::class));
             //            //            ld('params: ', $method->getParameters());
             //            ld('return type: ', $method->getReturnType());

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -260,7 +260,7 @@ trait ActivityLoggable
                 $relationships[] = [
                     'method' => $method->getName(),
                     'relation' => $method->getReturnType()->getName(),
-                    'foreignKeys' => $model->{$method->getName()}()->getForeignKeyName(),
+                    'foreignKey' => $model->{$method->getName()}()->getForeignKeyName(),
                     'localKey' => method_exists($model->{$method->getName()}(), 'getOwnerKeyName') ? $model->{$method->getName()}()->getOwnerKeyName() : $model->{$method->getName()}()->getLocalKeyName(),
                 ];
             }

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -144,7 +144,8 @@ trait ActivityLoggable
                 $from = $modelClass && $modelClass::find($from) ? $modelClass::find($from)->determineModelLabel() : '+';
                 $to = $modelClass && $modelClass::find($to) ? $modelClass::find($to)->determineModelLabel() : '+';
 
-                $key = $modelClass::find($from)->determineModelLabel();
+                //                $key = $modelClass::find($from)->determineModelLabel();
+                $key = (new $modelClass)->determineModelLabel();
             }
         }
 

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -266,7 +266,7 @@ trait ActivityLoggable
                     'method' => $method->getName(),
                     'relation' => $method->getReturnType(),
                     'foreignKeys' => $model->{$method->getName()}()->getForeignKeyName(),
-                    'localKey' => $model->{$method->getName()}()->getLocalKeyName(),
+                    'localKey' => $model->{$method->getName()}()->getOwnerKeyName() ?? $model->{$method->getName()}()->getLocalKeyName(),
                 ];
 
             }

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -156,6 +156,7 @@ trait ActivityLoggable
                 ! empty($method->getReturnType()) &&
                 is_subclass_of((string) $method->getReturnType(), Relation::class)
             ) {
+
                 $relationships[] = [
                     'method' => $method->getName(),
                     'relation' => $method->getReturnType()->getName(),

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -187,9 +187,9 @@ trait ActivityLoggable
         $relationships = [];
 
         foreach ((new ReflectionClass($model))->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
-            ld('method: ', $method);
-            ld('method name: '.$method->getName());
-            ld('params: ', $method->getParameters());
+            //            ld('method: ', $method);
+            //            ld('method name: '.$method->getName());
+            //            ld('params: ', $method->getParameters());
             if ($method->class != get_class($model) ||
 //                ! empty($method->getParameters()) ||
                 $method->getName() == __FUNCTION__) {
@@ -198,7 +198,7 @@ trait ActivityLoggable
 
             try {
                 $return = $method->invoke($model);
-                ld('return: ', $return);
+                //                ld('return: ', $return);
 
                 if ($return instanceof Relation) {
                     $relationships[$method->getName()] = [
@@ -206,7 +206,7 @@ trait ActivityLoggable
                         'model' => (new ReflectionClass($return->getRelated()))->getName(),
                     ];
 
-                    ld('getModelRelationships relationship', $relationships);
+                    //                    ld('getModelRelationships relationship', $relationships);
                 }
             } catch (Exception $e) {
                 report($e);

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -249,15 +249,16 @@ trait ActivityLoggable
             ld('method: ', $method);
             ld('method name: '.$method->getName());
             ld('is sub class of relation', is_subclass_of((string) $method->getReturnType(), Relation::class));
-            ld('params: ', $method->getParameters());
+            //            ld('params: ', $method->getParameters());
             ld('return type: ', $method->getReturnType());
             ld('getname is function ', ($method->getName() == __FUNCTION__));
             if ($method->class != get_class($model) &&
 //                ! empty($method->getParameters()) ||
                 ! empty($method->getReturnType()) &&
                 ($returnType = (string) $method->getReturnType()) &&
-                is_subclass_of($returnType, Relation::class) &&
-                ($method->getName() == __FUNCTION__)) {
+                is_subclass_of($returnType, Relation::class)
+                //                ($method->getName() == __FUNCTION__)
+            ) {
 
                 ld('here');
                 $relationships[] = [

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -165,7 +165,7 @@ trait ActivityLoggable
     {
         ld('relations: ', self::$availableRelations);
 
-        ld('available relations', $this->getAvailableRelations());
+        //        ld('available relations', $this->getAvailableRelations());
 
         ld('model relationship', $this->getModelRelationships());
 
@@ -175,7 +175,8 @@ trait ActivityLoggable
         //        ld('relations', $this->getRelations());
         //        ld('this', $this);
 
-        return collect($this->getAvailableRelations())->keys()->filter(fn ($relationName) => $this->{$relationName}() instanceof BelongsTo)->mapWithKeys(fn ($item) => [$item => $this->{$item}->getForeignKey()])->toArray();
+        //        return collect($this->getAvailableRelations())->keys()->filter(fn ($relationName) => $this->{$relationName}() instanceof BelongsTo)->mapWithKeys(fn ($item) => [$item => $this->{$item}->getForeignKey()])->toArray();
+        return collect($this->getRelations())->keys()->filter(fn ($relationName) => $this->{$relationName}() instanceof BelongsTo)->mapWithKeys(fn ($item) => [$item => $this->{$item}->getForeignKey()])->toArray();
         // when ready cache this
         //        return Cache::rememberForever('model_relations_'.self::class, fn () => collect($this->getRelations())->keys()->filter(fn ($relationName) => $this->{$relationName}() instanceof BelongsTo)->mapWithKeys(fn ($item) => [$item => $this->{$item}->getForeignKey()])->toArray());
     }

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -133,6 +133,7 @@ trait ActivityLoggable
 
         if (in_array($attribute, collect($this->getActivityLogModelRelationFields())->pluck('foreignKey')->toArray())) {
 
+            ld('got into array for attribute: '.$attribute);
             $relation = collect($this->getActivityLogModelRelationFields())->where('foreignKey', $attribute)->first();
             ld('relation', $relation);
 

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -125,6 +125,10 @@ trait ActivityLoggable
 
     public function prepareModelChange($attribute, $from, $to): array
     {
+        ld('attribute', $attribute);
+        ld('from', $from);
+        ld('to', $to);
+
         $key = $attribute;
 
         if (in_array($attribute, collect($this->getActivityLogModelRelationFields())->pluck('foreignKey')->toArray())) {

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -193,6 +193,8 @@ trait ActivityLoggable
          * check if we have the model label in cache
          */
         if (Cache::has('model_key_'.class_basename($this))) {
+            ld('got into model key: '.'model_key_'.class_basename($this), 'it is: ', Cache::get('model_key_'.class_basename($this)));
+
             return Cache::get('model_key_'.class_basename($this));
         }
 
@@ -210,6 +212,8 @@ trait ActivityLoggable
                 return Cache::rememberForever('model_key_'.class_basename($this), fn () => $this->{$key});
             }
         }
+
+        ld('got here should throw exception');
 
         throw new ModelKeyNotDefinedException(__('activity-log.exceptions.model_key_not_defined', ['model' => class_basename($this)]));
     }

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -163,7 +163,7 @@ trait ActivityLoggable
 
     public function getActivityLogModelRelationFields(): array
     {
-        ld('relations: ', self::$availableRelations);
+        //        ld('relations: ', self::$availableRelations);
 
         //        ld('available relations', $this->getAvailableRelations());
 

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -244,16 +244,20 @@ trait ActivityLoggable
         $relationships = [];
 
         foreach ((new ReflectionClass($model))->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
-            //            ld('method: ', $method);
-            //            ld('method name: '.$method->getName());
-            //            ld('params: ', $method->getParameters());
-            //            ld('return type: ', $method->getReturnType());
+            ld('model class: ', $method->class);
+            ld('class: ', get_class($model));
+            ld('method: ', $method);
+            ld('method name: '.$method->getName());
+            ld('is sub class of relation', is_subclass_of((string) $method->getReturnType(), Relation::class));
+            ld('params: ', $method->getParameters());
+            ld('return type: ', $method->getReturnType());
+            ld('getname is function ', ($method->getName() == __FUNCTION__));
             if ($method->class != get_class($model) &&
 //                ! empty($method->getParameters()) ||
                 ! empty($method->getReturnType()) &&
                 ($returnType = (string) $method->getReturnType()) &&
                 is_subclass_of($returnType, Relation::class) &&
-                $method->getName() == __FUNCTION__) {
+                ($method->getName() == __FUNCTION__)) {
 
                 ld('here');
                 $relationships[] = [

--- a/src/Support/Traits/ActivityLoggable.php
+++ b/src/Support/Traits/ActivityLoggable.php
@@ -304,9 +304,4 @@ trait ActivityLoggable
             'type' => $type,
         ]);
     }
-
-    //    protected function modelRelation(): Collection
-    //    {
-    //        return collect([]);
-    //    }
 }


### PR DESCRIPTION
The overall summary of this is the 'modelRelation' goes away and is no longer needed. All fields are tracked and checked in the activity log.

You also do not need to manually redefine every relationship it's automatic.  

Model key and label can be over ridden on a per model basis.

You can also on a per model basis exclude extra fields you do not want to track.

New 


## Key Points

* Automatically get the realtionship fields and labels. 
* All fields are now included in diff not just the ones in modelRelation
* `modelRelation` can be removed
* Updated README and CHANGELOG


## Notes

* This will probably be version 2.0.0
* Tested on Flooring Lab https://github.com/DCODE-GROUP/flooringlab/pull/399