### PR TITLE
support flexible activity retrieval across related models.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 ## CHANGELOG
 
 lists items that might need to run manually.
+* 20250509
+
+Added – Support for `extra_models` parameter in the Activity Log API endpoint.
+`extra_models`: A comma-separated list of relationship method names to include related models' activities.
+
+When provided, the system will dynamically load specified relationships, and include related models' activities in the query using `orWhere` clauses.
+This enhancement allows for broader and more flexible activity retrieval across related models.
+
+
 
 * 20250502
 

--- a/resources/js/components/VActivityLog.vue
+++ b/resources/js/components/VActivityLog.vue
@@ -317,6 +317,9 @@ export default {
       type: String,
       default: "No activity found",
     },
+    extra_models: {
+      type: String,
+    },
   },
 
   data() {
@@ -394,6 +397,7 @@ export default {
         modelClass: this.modelClass,
         modelId: this.modelId,
         ...{ timezone: this.timezone },
+        ...{ extra_models: this.extra_models },
         ...this.filters,
       };
       return axios

--- a/src/Http/Controllers/API/ActivityLogController.php
+++ b/src/Http/Controllers/API/ActivityLogController.php
@@ -7,6 +7,9 @@ use Dcodegroup\ActivityLog\Resources\ActivityLogCollection;
 use Dcodegroup\ActivityLog\Support\QueryBuilder\Filters\DateRangeFilter;
 use Dcodegroup\ActivityLog\Support\QueryBuilder\Filters\TermFilter;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Routing\Controller;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\QueryBuilder;
@@ -16,13 +19,40 @@ class ActivityLogController extends Controller
     public function __invoke(ExistingRequest $request): ActivityLogCollection
     {
         $communication = config('activity-log.communication_log_relationship');
-        // @phpstan-ignore-next-line
-        $query = QueryBuilder::for(config('activity-log.activity_log_model'))
-            ->when($request->has('modelClass'), fn (Builder $q) => $q->where('activitiable_type', $request->input('modelClass')))
-            ->when($request->has('modelId'), fn (Builder $q) => $q->where('activitiable_id', $request->input('modelId')))
-            ->where(fn (Builder $builder) => $builder
+
+
+        $queryBuilder = QueryBuilder::for(config('activity-log.activity_log_model'))->where(fn($query) => $query
+            ->when($request->has('modelClass'), fn(Builder $q) => $q->where('activitiable_type', $request->input('modelClass')))
+            ->when($request->has('modelId'), fn(Builder $q) => $q->where('activitiable_id', $request->input('modelId'))));
+
+        if ($request->has('modelClass') && $request->has('modelId') && $request->has('extra_models')) {
+            $modelClass = $request->input('modelClass');
+            $modelId = $request->input('modelId');
+            $extraModels =explode(',' , $request->input('extra_models'));
+            if (class_exists($modelClass) && is_subclass_of($modelClass, Model::class)) {
+                $model = $modelClass::find($modelId);
+                if ($model) {
+                    foreach ($extraModels as $relation) {
+                        if (method_exists($model, $relation)) {
+                            if ($model->$relation() instanceof Relation) {
+                                $relatedItems = $model->$relation;
+                                $relatedTable = $model->$relation()->getRelated();
+
+                                if ($relatedItems instanceof Collection) {
+                                    $queryBuilder->orWhere(fn($query) => $query->where('activitiable_type', get_class($relatedTable))->whereIn('activitiable_id', $relatedItems->pluck('id')->toArray()));
+                                } else if ($relatedItems) {
+                                    $queryBuilder->orWhere(fn($query) => $query->where('activitiable_type', get_class($relatedTable))->where('activitiable_id', $relatedItems->pluck('id')->toArray()));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        $query = $queryBuilder
+            ->where(fn(Builder $builder) => $builder
                 ->whereNull('communication_log_id')
-                ->orWhere(fn (Builder $builder) => $builder
+                ->orWhere(fn(Builder $builder) => $builder
                     ->whereNotNull('communication_log_id')
                     ->whereNot('title', 'like', '% read an %')
                     ->whereNot('title', 'like', '% view a %'))

--- a/src/Http/Controllers/API/ActivityLogController.php
+++ b/src/Http/Controllers/API/ActivityLogController.php
@@ -20,15 +20,14 @@ class ActivityLogController extends Controller
     {
         $communication = config('activity-log.communication_log_relationship');
 
-
-        $queryBuilder = QueryBuilder::for(config('activity-log.activity_log_model'))->where(fn($query) => $query
-            ->when($request->has('modelClass'), fn(Builder $q) => $q->where('activitiable_type', $request->input('modelClass')))
-            ->when($request->has('modelId'), fn(Builder $q) => $q->where('activitiable_id', $request->input('modelId'))));
+        $queryBuilder = QueryBuilder::for(config('activity-log.activity_log_model'))->where(fn ($query) => $query
+            ->when($request->has('modelClass'), fn (Builder $q) => $q->where('activitiable_type', $request->input('modelClass')))
+            ->when($request->has('modelId'), fn (Builder $q) => $q->where('activitiable_id', $request->input('modelId'))));
 
         if ($request->has('modelClass') && $request->has('modelId') && $request->has('extra_models')) {
             $modelClass = $request->input('modelClass');
             $modelId = $request->input('modelId');
-            $extraModels =explode(',' , $request->input('extra_models'));
+            $extraModels = explode(',', $request->input('extra_models'));
             if (class_exists($modelClass) && is_subclass_of($modelClass, Model::class)) {
                 $model = $modelClass::find($modelId);
                 if ($model) {
@@ -39,9 +38,9 @@ class ActivityLogController extends Controller
                                 $relatedTable = $model->$relation()->getRelated();
 
                                 if ($relatedItems instanceof Collection) {
-                                    $queryBuilder->orWhere(fn($query) => $query->where('activitiable_type', get_class($relatedTable))->whereIn('activitiable_id', $relatedItems->pluck('id')->toArray()));
-                                } else if ($relatedItems) {
-                                    $queryBuilder->orWhere(fn($query) => $query->where('activitiable_type', get_class($relatedTable))->where('activitiable_id', $relatedItems->pluck('id')->toArray()));
+                                    $queryBuilder->orWhere(fn ($query) => $query->where('activitiable_type', get_class($relatedTable))->whereIn('activitiable_id', $relatedItems->pluck('id')->toArray()));
+                                } elseif ($relatedItems) {
+                                    $queryBuilder->orWhere(fn ($query) => $query->where('activitiable_type', get_class($relatedTable))->where('activitiable_id', $relatedItems->pluck('id')->toArray()));
                                 }
                             }
                         }
@@ -50,9 +49,9 @@ class ActivityLogController extends Controller
             }
         }
         $query = $queryBuilder
-            ->where(fn(Builder $builder) => $builder
+            ->where(fn (Builder $builder) => $builder
                 ->whereNull('communication_log_id')
-                ->orWhere(fn(Builder $builder) => $builder
+                ->orWhere(fn (Builder $builder) => $builder
                     ->whereNotNull('communication_log_id')
                     ->whereNot('title', 'like', '% read an %')
                     ->whereNot('title', 'like', '% view a %'))


### PR DESCRIPTION
## Kanopi

## Key Points
-support flexible activity retrieval across related models.
## Manual Actions

## Notes
- Add   `extra_models` into v-activity-log props component
![Screenshot 2025-05-09 at 11 59 17](https://github.com/user-attachments/assets/6d7531a2-e03d-408f-bb50-3dbe3daf0639)
The system will automatically fetch all activity logs of the requested extra model into the activity log listing.

## Screenshots
This is an example I made when i want get activity log of a subcontractor with the activity log of the task and its associated subcontractor driver as well


https://github.com/user-attachments/assets/d1caf499-e257-4dc7-977b-be58ee7b2711

