### PR TITLE
Feature/pre 3832 restore edit and preview functionality in precision activity log

### DIFF
--- a/resources/js/components/ActivityLogModal.vue
+++ b/resources/js/components/ActivityLogModal.vue
@@ -10,7 +10,7 @@
             class="-ml-1 flex h-xlSpace w-xlSpace cursor-pointer items-center justify-center rounded hover:bg-tertiary-100"
             @click="close"
           >
-            <v-icon icon="XMarkIcon"></v-icon>
+            <icon icon="XMarkIcon"></icon>
           </span>
         </div>
         <slot>
@@ -47,9 +47,12 @@
   </div>
 </template>
 <script>
+import Icon from "./common/Icon.vue";
+
 export default {
   name: "ActivityLogModal",
   inject: ["bus"],
+  components: { Icon },
   data() {
     return {
       isOpen: false,

--- a/resources/js/components/VActivityLog.vue
+++ b/resources/js/components/VActivityLog.vue
@@ -210,7 +210,7 @@
                   ></icon>
                 </a>
               </div>
-              <div v-if="activity.type === 'Comment' && allowAction">
+              <div v-if="activity.type === 'Comment' && !isWidgetView">
                 <action
                   :activity="activity"
                   :get-url="getUrl"

--- a/resources/js/components/common/Comment.vue
+++ b/resources/js/components/common/Comment.vue
@@ -167,7 +167,7 @@ export default {
       }
     },
     cancel() {
-      this.bus.$emit("cancelEditComment");
+      this.$emit("cancelEditComment");
     },
     addComment() {
       if (!this.comment || this.loading) {
@@ -187,8 +187,8 @@ export default {
           .patch(this.commentUrl + "/" + this.activity.id, params)
           .then(({ data }) => {
             this.loading = false;
-            this.bus.$emit("cancelEditComment");
-            this.bus.$emit("closeActivityLogModal");
+            this.$emit("cancelEditComment");
+            this.$emit("addComment", data.data);
           })
           .catch(console.error);
       } else {
@@ -197,7 +197,7 @@ export default {
           .then(({ data }) => {
             this.comment = null;
             this.loading = false;
-            this.bus.$emit("refreshActivityLog", data.data);
+            this.$emit("addComment", data.data);
           })
           .catch(console.error);
       }

--- a/resources/js/components/common/Comment.vue
+++ b/resources/js/components/common/Comment.vue
@@ -66,9 +66,9 @@
         </div>
         <div
           :class="{
-            'content__action-button--disable': loading || (activity
-              ? activity.meta === comment || !comment
-              : !comment),
+            'content__action-button--disable':
+              loading ||
+              (activity ? activity.meta === comment || !comment : !comment),
           }"
           class="content__action-button cursor-pointer"
           @click="addComment"

--- a/resources/js/components/common/Icon.vue
+++ b/resources/js/components/common/Icon.vue
@@ -18,6 +18,7 @@ import {
   TrashIcon,
   PhoneIcon,
   ArrowDownTrayIcon,
+  XMarkIcon,
 } from "@heroicons/vue/24/outline";
 
 export default {
@@ -37,6 +38,7 @@ export default {
     ArrowDownTrayIcon,
     EllipsisHorizontalIcon,
     TrashIcon,
+    XMarkIcon,
   },
   props: {
     icon: {


### PR DESCRIPTION
## Kanopi
https://kanopi.live/app/ticket/54545/edit

## Key Points
- Fix pass event from event bus and 2 component
- Fix open email  modal
## Screenshots


https://github.com/user-attachments/assets/799ef775-bcf7-4196-9fe0-1b39208da47e

