### PR TITLE
Feature/dco 3117 option to queue emails from comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,16 @@ return [
 
     'open_modal_event' => env('LARAVEL_ACTIVITY_LOG_EVENT_OPEN_MODEL', 'openModal'),
     'reload_event' => env('LARAVEL_ACTIVITY_LOG_EVENT_RELOAD', 'getActivities'),
+    
+    /*
+     |--------------------------------------------------------------------------
+     | Email Queue Name
+     | eg 'sync' or 'redis'
+     |--------------------------------------------------------------------------
+     |
+    */
+
+    'queue_name' => env('LARAVEL_ACTIVITY_LOG_QUEUE_CONNECTION', 'sync'),
 ];
 
 

--- a/config/activity-log.php
+++ b/config/activity-log.php
@@ -130,6 +130,6 @@ return [
     */
 
     'queue_names' => [
-        'mention' => env('LARAVEL_ACTIVITY_LOG_MENTION_QUEUE_CONNECTION', 'redis')
+        'mention' => env('LARAVEL_ACTIVITY_LOG_MENTION_QUEUE_CONNECTION', 'redis'),
     ],
 ];

--- a/config/activity-log.php
+++ b/config/activity-log.php
@@ -129,7 +129,5 @@ return [
      |
     */
 
-    'queue_names' => [
-        'mention' => env('LARAVEL_ACTIVITY_LOG_MENTION_QUEUE_CONNECTION', 'redis'),
-    ],
+    'queue_name' => env('LARAVEL_ACTIVITY_LOG_QUEUE_CONNECTION', 'sync'),
 ];

--- a/config/activity-log.php
+++ b/config/activity-log.php
@@ -121,4 +121,15 @@ return [
 
     'open_modal_event' => env('LARAVEL_ACTIVITY_LOG_EVENT_OPEN_MODEL', 'openModal'),
     'reload_event' => env('LARAVEL_ACTIVITY_LOG_EVENT_RELOAD', 'getActivities'),
+
+    /*
+     |--------------------------------------------------------------------------
+     | Email Queue Names
+     |--------------------------------------------------------------------------
+     |
+    */
+
+    'queue_names' => [
+        'mention' => env('LARAVEL_ACTIVITY_LOG_MENTION_QUEUE_CONNECTION', 'redis')
+    ],
 ];

--- a/src/Http/Services/ActivityLogService.php
+++ b/src/Http/Services/ActivityLogService.php
@@ -2,7 +2,7 @@
 
 namespace Dcodegroup\ActivityLog\Http\Services;
 
-use Dcodegroup\ActivityLog\Mail\CommentNotification;
+use Dcodegroup\ActivityLog\Jobs\SendCommentNotificationJob;
 use Dcodegroup\ActivityLog\Models\ActivityLog;
 use Dcodegroup\ActivityLog\Resources\ActivityLogCollection;
 use Illuminate\Database\Eloquent\Builder;
@@ -97,7 +97,8 @@ class ActivityLogService
                             // @phpstan-ignore-next-line
                             $data['action'] = ! empty($model->getMentionCommentUrl($userModel)) ? $model->getMentionCommentUrl($userModel) : $mailable['action'];
                         }
-                        Mail::to($email)->send(new CommentNotification($data, $model));
+
+                        SendCommentNotificationJob::dispatch($email, $data, $model);
                     }
                     $to = is_array($email) ? implode(', ', $email) : $email;
                     $comment = str_replace($key, '<a class="activity__comment--tag" href="mailto:'.$to.'">@'.$userModel->getActivityLogUserName().'</a>', $comment);

--- a/src/Http/Services/ActivityLogService.php
+++ b/src/Http/Services/ActivityLogService.php
@@ -7,7 +7,6 @@ use Dcodegroup\ActivityLog\Models\ActivityLog;
 use Dcodegroup\ActivityLog\Resources\ActivityLogCollection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Str;
 
 class ActivityLogService

--- a/src/Jobs/SendCommentNotificationJob.php
+++ b/src/Jobs/SendCommentNotificationJob.php
@@ -19,7 +19,7 @@ class SendCommentNotificationJob implements ShouldQueue
 
     public function __construct(protected string $email, protected array $emailContent, protected $entityModel)
     {
-        $this->onQueue(config('queue.queue_names.mention'));
+        $this->onQueue(config('activity-log.queue_names.mention'));
     }
 
     public function handle(): void

--- a/src/Jobs/SendCommentNotificationJob.php
+++ b/src/Jobs/SendCommentNotificationJob.php
@@ -19,7 +19,7 @@ class SendCommentNotificationJob implements ShouldQueue
 
     public function __construct(protected string $email, protected array $emailContent, protected $entityModel)
     {
-        $this->onQueue(config('activity-log.queue_names.mention'));
+        $this->onQueue(config('activity-log.queue_name'));
     }
 
     public function handle(): void

--- a/src/Jobs/SendCommentNotificationJob.php
+++ b/src/Jobs/SendCommentNotificationJob.php
@@ -19,7 +19,7 @@ class SendCommentNotificationJob  implements ShouldQueue
 
     public function __construct(protected string $email, protected array $emailContent, protected $entityModel)
     {
-        $this->onQueue(config('queue.queue_names.default'));
+        $this->onQueue(config('queue.queue_names.mention'));
     }
 
     public function handle(): void

--- a/src/Jobs/SendCommentNotificationJob.php
+++ b/src/Jobs/SendCommentNotificationJob.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Dcodegroup\ActivityLog\Jobs;
+
+use Dcodegroup\ActivityLog\Mail\CommentNotification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Bus\Queueable;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Mail;
+
+class SendCommentNotificationJob  implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(protected string $email, protected array $emailContent, protected $entityModel)
+    {
+        $this->onQueue(config('queue.queue_names.default'));
+    }
+
+    public function handle(): void
+    {
+        Mail::to($this->email)->send(new CommentNotification($this->emailContent, $this->entityModel));
+    }
+}

--- a/src/Jobs/SendCommentNotificationJob.php
+++ b/src/Jobs/SendCommentNotificationJob.php
@@ -3,14 +3,14 @@
 namespace Dcodegroup\ActivityLog\Jobs;
 
 use Dcodegroup\ActivityLog\Mail\CommentNotification;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Mail;
 
-class SendCommentNotificationJob  implements ShouldQueue
+class SendCommentNotificationJob implements ShouldQueue
 {
     use Dispatchable;
     use InteractsWithQueue;

--- a/src/Mail/CommentNotification.php
+++ b/src/Mail/CommentNotification.php
@@ -3,13 +3,14 @@
 namespace Dcodegroup\ActivityLog\Mail;
 
 use Dcodegroup\ActivityLog\Support\Traits\ReadMailableTrait;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 
-class CommentNotification extends Mailable
+class CommentNotification extends Mailable implements ShouldQueue
 {
     use Queueable;
     use ReadMailableTrait;

--- a/src/Mail/CommentNotification.php
+++ b/src/Mail/CommentNotification.php
@@ -3,8 +3,8 @@
 namespace Dcodegroup\ActivityLog\Mail;
 
 use Dcodegroup\ActivityLog\Support\Traits\ReadMailableTrait;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;


### PR DESCRIPTION
## Kanopi
https://kanopi.live/app/ticket/51045/edit?tab=details
<!-- Link to the Kanopi ticket | Add link to demo eg wip or upgrade environment if one exists -->


## Key Points

<!-- Describe the main changes here -->

- [x] Option to queue emails from comments

## Notes

- Support change mention queue connection type by `LARAVEL_ACTIVITY_LOG_QUEUE_CONNECTION ` env

## Key Points

## Screenshots
<img width="1679" height="152" alt="Screenshot 2026-01-07 at 14 52 44" src="https://github.com/user-attachments/assets/61f1ae59-6c28-4f2e-8a3e-72fdb8d4e8f7" />

