### PR TITLE
Change queue name config

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,12 +307,11 @@ return [
     /*
      |--------------------------------------------------------------------------
      | Email Queue Name
-     | eg 'sync' or 'redis'
      |--------------------------------------------------------------------------
      |
     */
 
-    'queue_name' => env('LARAVEL_ACTIVITY_LOG_QUEUE_CONNECTION', 'sync'),
+    'queue_name' => env('LARAVEL_ACTIVITY_LOG_QUEUE_NAME', 'default'),
 ];
 
 

--- a/config/activity-log.php
+++ b/config/activity-log.php
@@ -129,5 +129,5 @@ return [
      |
     */
 
-    'queue_name' => env('LARAVEL_ACTIVITY_LOG_QUEUE_CONNECTION', 'sync'),
+    'queue_name' => env('LARAVEL_ACTIVITY_LOG_QUEUE_NAME', 'default'),
 ];


### PR DESCRIPTION

## Key Points
- Change queue name config.
- Default value = default. Options : email , jobs , media