### PR TITLE
Feature/allow full comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 lists items that might need to run manually.
 
+* 20260217
+  Add ability to pass a new flag through to show the full comment text and not have to expand it.
+
 * 20250612
   The package provides the following listener:
 

--- a/resources/js/components/VActivityLog.vue
+++ b/resources/js/components/VActivityLog.vue
@@ -77,8 +77,8 @@
       <template v-if="activities.length">
         <div
           v-for="(activity, index) in activities"
-          class="activity activity--min relative !mt-0 pl-0"
           :class="{ 'pt-8': !isWidgetView, 'pb-lgSpace': isWidgetView }"
+          class="activity activity--min relative !mt-0 pl-0"
         >
           <div
             v-show="index < activities.length - 1"
@@ -147,10 +147,10 @@
                       </button>
                       <button
                         v-if="allowResend"
+                        :disabled="resent"
                         class="btn btn--secondary max-h-[32px] rounded-lg"
                         type="button"
                         @click="resentCommunication(activity.communication)"
-                        :disabled="resent"
                       >
                         <div
                           class="flex items-center flex-row-reverse space-x-reverse"
@@ -186,6 +186,7 @@
                     <read-more-content
                       :content="activity.description"
                       :is-edited="activity.is_edited"
+                      :show-full-comment="showFullComment"
                     ></read-more-content>
                   </div>
                   <div
@@ -193,8 +194,8 @@
                     class="flex items-center space-x-2 sm:flex-col sm:space-x-0 sm:space-y-smSpace sm:items-start py-smSpace"
                   >
                     <a
-                      class="btn btn--secondary max-h-[32px] rounded-lg"
                       :href="activity.meta"
+                      class="btn btn--secondary max-h-[32px] rounded-lg"
                     >
                       <div
                         class="flex items-center flex-row-reverse space-x-reverse"
@@ -377,6 +378,10 @@ export default {
     },
     extra_models: {
       type: String,
+    },
+    showFullComment: {
+      type: Boolean,
+      default: false,
     },
   },
 

--- a/resources/js/components/common/ReadMoreContent.vue
+++ b/resources/js/components/common/ReadMoreContent.vue
@@ -1,14 +1,19 @@
 <template>
   <div>
     <div class="readmore-container">
-      <span v-if="!isOpen && isNeedStrip" v-html="stripedContent"></span>
+      <span
+        v-if="!isOpen && isNeedStrip && !showFullComment"
+        v-html="stripedContent"
+      ></span>
       <span v-else v-html="content"></span>
-      <span v-if="isEdited" class="readmore-container--edited"
+      <span
+        v-if="isEdited && !showFullComment"
+        class="readmore-container--edited"
         >({{ $t("activity-log.words.edited") }})</span
       >
     </div>
-    <template v-if="this.enable && isNeedStrip">
-      <a @click.prevent="toggle" class="inline text-blue-600 cursor-pointer">{{
+    <template v-if="this.enable && isNeedStrip && !showFullComment">
+      <a class="inline text-blue-600 cursor-pointer" @click.prevent="toggle">{{
         isOpen
           ? $t("activity-log.words.read_less")
           : $t("activity-log.words.read_more")
@@ -34,6 +39,10 @@ export default {
       default: true,
     },
     open: {
+      type: Boolean,
+      default: false,
+    },
+    showFullComment: {
       type: Boolean,
       default: false,
     },


### PR DESCRIPTION
## Key Points

This pull request adds a new feature that allows the full comment text to be shown in activity logs without requiring the user to expand it manually. The implementation introduces a new `showFullComment` flag, which is passed through the relevant components and used to control the display logic. Minor improvements and code cleanups are also included.

**Feature: Show Full Comment Text**

* Added a `showFullComment` prop to both `VActivityLog.vue` and `ReadMoreContent.vue` components, allowing the full comment text to be displayed without user interaction. [[1]](diffhunk://#diff-6babe6d67273c9b07a470b5a05313d5761cdd6e61c38548e0b0e7b2f3ca21309R382-R385) [[2]](diffhunk://#diff-afdf64a7ab086fcf6bcec12d7e421dd0517e80d5b4047c35c18d580755fb88c4R45-R48)
* Updated the logic in `ReadMoreContent.vue` to bypass the "read more/less" toggle when `showFullComment` is true, ensuring the entire comment is shown by default.
* Passed the `showFullComment` prop from `VActivityLog.vue` to `ReadMoreContent.vue` where activity descriptions are rendered.
* Documented the new flag and its purpose in the `CHANGELOG.md`.

**Minor Improvements**

* Fixed the `:disabled` attribute placement for the resend button in `VActivityLog.vue` for improved clarity and correctness.
* Minor formatting adjustments to class attribute ordering in `VActivityLog.vue`.


