### PR TITLE
🚨 SECURITY: Pin axios to 1.13.6 (supply chain attack)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@vitejs/plugin-vue": "^6.0.0",
     "@vue/compiler-sfc": "^3.2.33",
     "autoprefixer": "10.4.5",
-    "axios": "1.7.8",
+    "axios": "1.13.6",
     "concurrently": "^9.2.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
@@ -49,5 +49,8 @@
   "dependencies": {
     "laravel-vue-i18n": "^2.7.6",
     "vue-i18n": "^9.14.4"
+  },
+  "overrides": {
+    "axios": "1.13.6"
   }
 }

--- a/workbench/app/Models/Ticket.php
+++ b/workbench/app/Models/Ticket.php
@@ -3,8 +3,9 @@
 namespace Workbench\App\Models;
 
 use Dcodegroup\ActivityLog\Support\Traits\ActivityLoggable;
+use Illuminate\Database\Eloquent\Model;
 
-class Ticket extends \Illuminate\Database\Eloquent\Model
+class Ticket extends Model
 {
     use ActivityLoggable;
 

--- a/workbench/database/factories/UserFactory.php
+++ b/workbench/database/factories/UserFactory.php
@@ -10,7 +10,7 @@ use Workbench\App\Models\User;
 /**
  * @template TModel of \Workbench\App\Models\User
  *
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<TModel>
+ * @extends Factory<TModel>
  */
 class UserFactory extends Factory
 {


### PR DESCRIPTION
## axios supply chain attack — March 31 2026

Malicious versions `axios@1.14.1` and `axios@0.30.4` were published via compromised maintainer credentials. They inject `plain-crypto-js@4.2.1` which drops a cross-platform RAT.

### Changes
- Pins axios to `1.13.6` (last safe release)
- Adds `overrides` to block transitive resolution to compromised versions
- Regenerates lockfile

### Action required
If any machine has already installed the compromised version, treat it as compromised:
- Rotate all secrets/credentials
- Check for C2 connections to `sfrclak.com` / `142.11.206.73`
- Look for: `/Library/Caches/com.apple.act.mond` (mac), `%PROGRAMDATA%\wt.exe` (win), `/tmp/ld.py` (linux)

### References
- https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan
- https://news.ycombinator.com/item?id=47581837