### PR TITLE
Ensure only comments are queried/returned when a comment is posted

### DIFF
--- a/src/Http/Controllers/API/CommentController.php
+++ b/src/Http/Controllers/API/CommentController.php
@@ -41,6 +41,6 @@ class CommentController extends Controller
             $this->service->mentionUserInComment($comment, $activity, $email);
         }
 
-        return $this->service->getActivityLogs($model);
+        return $this->service->getActivityLogs($model, ActivityLog::TYPE_COMMENT);
     }
 }

--- a/src/Http/Services/ActivityLogService.php
+++ b/src/Http/Services/ActivityLogService.php
@@ -34,9 +34,10 @@ class ActivityLogService
         $this->communicationLogRelationship = config('activity-log.communication_log_relationship');
     }
 
-    public function getActivityLogs($model): ActivityLogCollection
+    public function getActivityLogs($model, $type = null): ActivityLogCollection
     {
         return new ActivityLogCollection($model->activityLogs()
+            ->when($type, fn (Builder $builder) => $builder->where('type', $type))
             ->with([
                 $this->userRelationship,
                 $this->communicationLogRelationship,


### PR DESCRIPTION
## Kanopi

https://kanopi.live/app/ticket/63508/edit?tab=github

## Key Points

When a comment was posted, the controller was retrieving and returning *all* activity logs, not just comments.

This patch adjusts it so that only comment type activities are returned, increasing speed.


