### PR TITLE
Upgrade composer packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tests/temp
 build
 node_modules
 package-lock.json
+pnpm-lock.yaml

--- a/composer.json
+++ b/composer.json
@@ -26,19 +26,19 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "coduo/php-to-string": "^3.2",
-        "laravel/framework": "^10.2|^11.0|^12.0",
+        "laravel/framework": "^11.0|^12.0|^13.0",
         "nesbot/carbon": "^2.72|^3.0",
-        "spatie/laravel-query-builder": "^4.0.4|^5.7|^6.0"
+        "spatie/laravel-query-builder": "^5.7|^6.0|^7.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.42",
-        "larastan/larastan": "^2.9",
+        "larastan/larastan": "^3.0",
         "laravel/pint": "^1.13",
-        "orchestra/testbench": "^9.14",
-        "phpstan/phpstan-deprecation-rules": "^1.1",
-        "phpstan/phpstan-phpunit": "^1.3",
+        "orchestra/testbench": "^11.0",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
         "spatie/laravel-log-dumper": "^1.5"
     },
     "minimum-stability": "dev",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,6 +8,8 @@ parameters:
         - config
         - database
     tmpDir: build/phpstan
+    configDirectories:
+        - config/
 
     checkOctaneCompatibility: true
     checkModelProperties: true
@@ -18,3 +20,5 @@ parameters:
         - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\\Model::allowedFilters#'
         - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Model::getActivityLogUserName#'
         - '#Class App\\Models\\User not found#'
+        - '#Trait Dcodegroup\\ActivityLog\\Support\\Traits\\ModelDeterminable is used zero times and is not analysed#'
+        - '#Trait Dcodegroup\\ActivityLog\\Support\\Traits\\ActivityLoggable is used zero times and is not analysed#'

--- a/src/Http/Controllers/API/ActivityLogController.php
+++ b/src/Http/Controllers/API/ActivityLogController.php
@@ -3,6 +3,7 @@
 namespace Dcodegroup\ActivityLog\Http\Controllers\API;
 
 use Dcodegroup\ActivityLog\Http\Requests\ExistingRequest;
+use Dcodegroup\ActivityLog\Models\ActivityLog;
 use Dcodegroup\ActivityLog\Resources\ActivityLogCollection;
 use Dcodegroup\ActivityLog\Support\QueryBuilder\Filters\DateRangeFilter;
 use Dcodegroup\ActivityLog\Support\QueryBuilder\Filters\TermFilter;
@@ -20,7 +21,9 @@ class ActivityLogController extends Controller
     {
         $communication = config('activity-log.communication_log_relationship');
 
-        // @phpstan-ignore-next-line
+        /**
+         * @var QueryBuilder<ActivityLog> $queryBuilder
+         */
         $queryBuilder = QueryBuilder::for(config('activity-log.activity_log_model'))
             ->where(fn ($query) => $query
                 ->when($request->has('modelClass'), fn (Builder $q) => $q->where('activitiable_type', $request->input('modelClass')))
@@ -70,8 +73,23 @@ class ActivityLogController extends Controller
                 }
             }
         }
-        // @phpstan-ignore-next-line
+
         $query = $queryBuilder
+            ->allowedFilters(
+                'created_by',
+                AllowedFilter::exact('id'),
+                AllowedFilter::exact('type'),
+                AllowedFilter::custom('date', new DateRangeFilter('created_at')),
+                AllowedFilter::custom('term', new TermFilter),
+            )
+            ->allowedSorts(
+                'id',
+                'created_by',
+                'activitiable_type',
+                'content',
+                'created_at',
+            )
+            ->defaultSort('-id')
             ->where(fn (Builder $builder) => $builder
                 ->whereNull('communication_log_id')
                 ->orWhere(fn (Builder $builder) => $builder
@@ -83,22 +101,7 @@ class ActivityLogController extends Controller
                 config('activity-log.user_relationship'),
                 $communication,
                 "$communication.reads",
-            ])
-            ->allowedFilters([
-                'created_by',
-                AllowedFilter::exact('id'),
-                AllowedFilter::exact('type'),
-                AllowedFilter::custom('date', new DateRangeFilter('created_at')),
-                AllowedFilter::custom('term', new TermFilter),
-            ])
-            ->allowedSorts([
-                'id',
-                'created_by',
-                'activitiable_type',
-                'content',
-                'created_at',
-            ])
-            ->defaultSort('-id');
+            ]);
 
         return new ActivityLogCollection(
             $query->paginate($request->has('pagination') ? $request->input('pagination') : config('activity-log.default_filter_pagination'))

--- a/src/Models/ActivityLog.php
+++ b/src/Models/ActivityLog.php
@@ -53,11 +53,6 @@ class ActivityLog extends Model
         self::TYPE_PHONE => 'orange',
     ];
 
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
     protected $fillable = [
         'activitiable_type',
         'activitiable_id',

--- a/src/Models/CommunicationLog.php
+++ b/src/Models/CommunicationLog.php
@@ -29,11 +29,6 @@ class CommunicationLog extends Model
         self::TYPE_EMAIL => 'EnvelopeIcon',
     ];
 
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
     protected $fillable = [
         'type',
         'to',

--- a/src/Support/QueryBuilder/Filters/DateRangeFilter.php
+++ b/src/Support/QueryBuilder/Filters/DateRangeFilter.php
@@ -14,9 +14,8 @@ class DateRangeFilter implements Filter
         $this->propertyOverride = $propertyOverride;
     }
 
-    public function __invoke(Builder $query, $value, string $property): Builder
+    public function __invoke(Builder $query, $value, string $property): void
     {
-        // @phpstan-ignore-next-line
-        return $query->whereBetween($this->propertyOverride ?? $property, $value);
+        $query->whereBetween($this->propertyOverride ?? $property, $value);
     }
 }

--- a/src/Support/QueryBuilder/Filters/TermFilter.php
+++ b/src/Support/QueryBuilder/Filters/TermFilter.php
@@ -8,9 +8,9 @@ use Spatie\QueryBuilder\Filters\Filter;
 
 class TermFilter implements Filter
 {
-    public function __invoke(Builder $query, $value, string $property): Builder
+    public function __invoke(Builder $query, $value, string $property): void
     {
-        return $query->whereHas('user', function (Builder $q) use ($value) {
+        $query->whereHas('user', function (Builder $q) use ($value) {
             if (Schema::hasColumns('user', ['username', 'first_name', 'middle_name', 'last_name'])) {
                 return $q->where('username', 'like', "%$value%")
                     ->orWhere('first_name', 'like', "%$value%")


### PR DESCRIPTION
## Kanopi

Part of ticket DCO-2918
Updating to support Laravel 13 which required updating of other packages so updated all.

## Key Points

- Upgraded Composer Packages
- Fixed static analysis

## Notes

- Updated as needed for ticket DCO-2918
- Drops support for PHP8.2
- Drops support for Laravel 10
- Props support for spatie/laravel-query-builder v4

